### PR TITLE
Fixed time display 12/24h to show correct Locale

### DIFF
--- a/BatteryBoi/BBExtensions.swift
+++ b/BatteryBoi/BBExtensions.swift
@@ -194,11 +194,11 @@ extension Date {
         
         if let formatter = formatter {
             if formatter.contains("a") == true {
-                return self.string("HH:mm")
+                return self.string("hh:mm a")
                 
             }
             else {
-                return self.string("hh:mm a")
+                return self.string("HH:mm")
 
             }
             


### PR DESCRIPTION
Latest release shows a 12h locale even though system is set to 24h locale. This should fix it.