### PR TITLE
Add configurable battery threshold alerts

### DIFF
--- a/BatteryBoi/BatteryBoiApp.swift
+++ b/BatteryBoi/BatteryBoiApp.swift
@@ -137,6 +137,9 @@ enum SystemDefaultsKeys: String {
     case enabledProgressState = "sd_progress_state"
     case enabledPinned = "sd_pinned_mode"
 
+    case batteryMinChargeThreshold = "sd_battery_min_threshold"
+    case batteryMaxChargeThreshold = "sd_battery_max_threshold"
+
     case batteryUntilFull = "sd_charge_full"
     case batteryLastCharged = "sd_charge_last"
     case batteryDepletionRate = "sd_depletion_rate"
@@ -145,10 +148,10 @@ enum SystemDefaultsKeys: String {
     case versionInstalled = "sd_version_installed"
     case versionCurrent = "sd_version_current"
     case versionIdenfiyer = "sd_version_id"
-    
+
     case usageDay = "sd_usage_days"
     case usageTimestamp = "sd_usage_date"
-    
+
     case profileChecked = "sd_profiles_checked"
     case profilePayload = "sd_profiles_payload"
 
@@ -166,25 +169,28 @@ enum SystemDefaultsKeys: String {
             case .enabledProgressState:return "Show Progress"
             case .enabledPinned:return "Pinned"
 
+            case .batteryMinChargeThreshold:return "Minimum Battery Threshold"
+            case .batteryMaxChargeThreshold:return "Maximum Charge Threshold"
+
             case .batteryUntilFull:return "Seconds until Charged"
             case .batteryLastCharged:return "Seconds until Charged"
             case .batteryDepletionRate:return "Battery Depletion Rate"
             case .batteryWindowPosition:return "Battery Window Positio"
-            
+
             case .versionInstalled:return "Installed on"
             case .versionCurrent:return "Active Version"
             case .versionIdenfiyer:return "App ID"
 
             case .usageDay:return "sd_usage_days"
             case .usageTimestamp:return "sd_usage_timestamp"
-            
+
             case .profileChecked:return "Profile Validated"
             case .profilePayload:return "Profile Payload"
 
         }
-        
+
     }
-    
+
 }
 
 @main

--- a/BatteryBoi/Objects/BBStatsManager.swift
+++ b/BatteryBoi/Objects/BBStatsManager.swift
@@ -319,6 +319,8 @@ class StatsManager:ObservableObject {
                 case .percentTen:return "AlertSomePercentTitle".localise([percent])
                 case .percentTwentyFive:return "AlertSomePercentTitle".localise([percent])
                 case .percentOne:return "AlertOnePercentTitle".localise()
+                case .percentMinThreshold:return "AlertSomePercentTitle".localise([percent])
+                case .percentMaxThreshold:return "AlertSomePercentTitle".localise([percent])
                 case .deviceConnected:return "AlertDeviceConnectedTitle".localise()
                 case .deviceRemoved:return "AlertDeviceDisconnectedTitle".localise()
                 case .deviceOverheating:return "AlertOverheatingTitle".localise()
@@ -370,6 +372,8 @@ class StatsManager:ObservableObject {
                 case .percentTen:return "AlertPercentSummary".localise()
                 case .percentTwentyFive:return "AlertPercentSummary".localise()
                 case .percentOne:return "AlertPercentSummary".localise()
+                case .percentMinThreshold:return "AlertPercentSummary".localise()
+                case .percentMaxThreshold:return "AlertChargeLimitSummary".localise()
                 case .userEvent:return "AlertLimitedSummary".localise([event?.name ?? "Unknown Event"])
                 case .deviceOverheating:return "AlertOverheatingSummary".localise()
                 default : break

--- a/BatteryBoi/Objects/BBWindowManager.swift
+++ b/BatteryBoi/Objects/BBWindowManager.swift
@@ -84,33 +84,32 @@ class WindowManager: ObservableObject {
             if BatteryManager.shared.charging.state == .battery {
                 // Custom minimum threshold alert
                 let minTh = SettingsManager.shared.minChargeThreshold
-                if minTh != .disabled && percent == minTh.rawValue {
+                if minTh != .disabled && percent == Double(minTh.rawValue) {
                     self.windowOpen(.percentMinThreshold, device: nil)
                 }
+                else {
+                    switch percent {
+                        case 25 : self.windowOpen(.percentTwentyFive, device: nil)
+                        case 10 : self.windowOpen(.percentTen, device: nil)
+                        case 5 : self.windowOpen(.percentFive, device: nil)
+                        case 1 : self.windowOpen(.percentOne, device: nil)
+                        default : break
 
-                switch percent {
-                    case 25 : self.windowOpen(.percentTwentyFive, device: nil)
-                    case 10 : self.windowOpen(.percentTen, device: nil)
-                    case 5 : self.windowOpen(.percentFive, device: nil)
-                    case 1 : self.windowOpen(.percentOne, device: nil)
-                    default : break
-                    
+                    }
                 }
-                
+
             }
             else {
                 // Custom maximum threshold alert
                 let maxTh = SettingsManager.shared.maxChargeThreshold
-                if maxTh != .disabled && percent == maxTh.rawValue {
+                if maxTh != .disabled && percent == Double(maxTh.rawValue) {
                     self.windowOpen(.percentMaxThreshold, device: nil)
-                } else {
-                    // Legacy behavior only if no custom threshold set
-                    if percent == 100 && SettingsManager.shared.enabledChargeEighty == .disabled && maxTh == .disabled {
-                        self.windowOpen(.chargingComplete, device: nil)
-                    }
-                    else if percent == 80 && SettingsManager.shared.enabledChargeEighty == .enabled && maxTh == .disabled {
-                        self.windowOpen(.chargingComplete, device: nil)
-                    }
+                }
+                else if percent == 100 && SettingsManager.shared.enabledChargeEighty == .disabled {
+                    self.windowOpen(.chargingComplete, device: nil)
+                }
+                else if percent == 80 && SettingsManager.shared.enabledChargeEighty == .enabled {
+                    self.windowOpen(.chargingComplete, device: nil)
                 }
 
             }

--- a/BatteryBoi/Other/Localization/en.lproj/LocalizableMain.strings
+++ b/BatteryBoi/Other/Localization/en.lproj/LocalizableMain.strings
@@ -54,6 +54,11 @@
 "SettingsNotificationsLabel" = "Notifications";
 "SettingsPrereleasesLabel" = "Beta Releases";
 
+"SettingsMinThresholdLabel" = "Low Battery Alert";
+"SettingsMaxThresholdLabel" = "Charge Limit Alert";
+
+"AlertChargeLimitSummary" = "Consider unplugging to preserve battery health.";
+
 "SettingsCustomizationMenuLabel" = "Menu Bar Icon";
 "SettingsCustomizationThemeDarkLabel" = "Dark";
 "SettingsCustomizationThemeLightLabel" = "Light";

--- a/BatteryBoi/Views/Component/BBSettingsView.swift
+++ b/BatteryBoi/Views/Component/BBSettingsView.swift
@@ -90,7 +90,17 @@ struct SettingsItem: View {
                 self.icon = self.settings.charge.icon
 
             }
-            
+            else if item.type == .customiseMinThreshold {
+                self.subtitle = self.settings.minChargeThreshold.subtitle
+                self.icon = self.settings.minChargeThreshold.icon
+
+            }
+            else if item.type == .customiseMaxThreshold {
+                self.subtitle = self.settings.maxChargeThreshold.subtitle
+                self.icon = self.settings.maxChargeThreshold.icon
+
+            }
+
         }
         .onChange(of: self.battery.saver, perform: { newValue in
             withAnimation(Animation.easeOut.delay(0.1)) {
@@ -147,7 +157,23 @@ struct SettingsItem: View {
                 self.icon = self.settings.charge.icon
 
             }
-            
+
+        })
+        .onChange(of: self.settings.minChargeThreshold, perform: { newValue in
+            if item.type == .customiseMinThreshold {
+                self.subtitle = newValue.subtitle
+                self.icon = newValue.icon
+
+            }
+
+        })
+        .onChange(of: self.settings.maxChargeThreshold, perform: { newValue in
+            if item.type == .customiseMaxThreshold {
+                self.subtitle = newValue.subtitle
+                self.icon = newValue.icon
+
+            }
+
         })
         .onTapGesture {
             SettingsManager.shared.settingsAction(item)

--- a/BatteryBoi/Views/Window/BBHUDView.swift
+++ b/BatteryBoi/Views/Window/BBHUDView.swift
@@ -15,6 +15,8 @@ enum HUDAlertTypes:Int {
     case percentTen
     case percentTwentyFive
     case percentOne
+    case percentMinThreshold
+    case percentMaxThreshold
     case userInitiated
     case userLaunched
     case userEvent
@@ -32,6 +34,8 @@ enum HUDAlertTypes:Int {
             case .percentTen : return .low
             case .percentFive : return .low
             case .percentOne : return .low
+            case .percentMinThreshold: return .low
+            case .percentMaxThreshold: return .low
             case .userLaunched : return nil
             case .userInitiated : return nil
             case .userEvent : return .low

--- a/BatteryBoi/Views/Window/BBHUDView.swift
+++ b/BatteryBoi/Views/Window/BBHUDView.swift
@@ -35,7 +35,7 @@ enum HUDAlertTypes:Int {
             case .percentFive : return .low
             case .percentOne : return .low
             case .percentMinThreshold: return .low
-            case .percentMaxThreshold: return .low
+            case .percentMaxThreshold: return .high
             case .userLaunched : return nil
             case .userInitiated : return nil
             case .userEvent : return .low


### PR DESCRIPTION
## Summary
- add configurable minimum and maximum battery threshold settings in preferences
- trigger HUD alerts when custom min/max thresholds are reached
- wire new threshold UI labels and localized copy for charge-limit guidance
- fix threshold comparison typing and prevent duplicate low-battery alerts when custom threshold matches defaults

## Test plan
- [ ] Launch app and verify new settings appear: **Low Battery Alert** and **Charge Limit Alert**
- [ ] Cycle low threshold and confirm subtitle updates (Disabled/10/15/20/.../50)
- [ ] Cycle max threshold and confirm subtitle updates (Disabled/70/75/80/.../100)
- [ ] On battery power, verify custom min alert fires at configured percentage
- [ ] On battery power, verify default 25/10/5/1 alerts still fire when custom min does not match
- [ ] While charging, verify custom max alert fires at configured percentage
- [ ] Verify max-threshold alert uses high sound effect
- [ ] With max threshold disabled, verify legacy 80/100 charging-complete behavior still works

Closes #59